### PR TITLE
perf: load sections lazily

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,26 @@
+import dynamic from "next/dynamic"
 import { Header } from "@/components/header"
 import { SectionWrapper } from "@/components/section-wrapper"
 import { Hero } from "@/components/hero"
-import { About } from "@/components/about"
-import { Skills } from "@/components/skills"
-import { Projects } from "@/components/projects"
-import { Contact } from "@/components/contact"
 import { Footer } from "@/components/footer"
 import { ScrollToTop } from "@/components/scroll-to-top"
+
+const About = dynamic(
+  () => import("@/components/about").then((m) => ({ default: m.About })),
+  { ssr: false },
+)
+const Skills = dynamic(
+  () => import("@/components/skills").then((m) => ({ default: m.Skills })),
+  { ssr: false },
+)
+const Projects = dynamic(
+  () => import("@/components/projects").then((m) => ({ default: m.Projects })),
+  { ssr: false },
+)
+const Contact = dynamic(
+  () => import("@/components/contact").then((m) => ({ default: m.Contact })),
+  { ssr: false },
+)
 
 export default function Home() {
   return (
@@ -15,25 +29,15 @@ export default function Home() {
 
       {/* Container para seções sobrepostas */}
       <div className="relative min-h-screen">
-        <SectionWrapper id="hero">
-          <Hero />
-        </SectionWrapper>
+        <SectionWrapper id="hero" component={Hero} />
 
-        <SectionWrapper id="sobre">
-          <About />
-        </SectionWrapper>
+        <SectionWrapper id="sobre" component={About} />
 
-        <SectionWrapper id="habilidades">
-          <Skills />
-        </SectionWrapper>
+        <SectionWrapper id="habilidades" component={Skills} />
 
-        <SectionWrapper id="projetos">
-          <Projects />
-        </SectionWrapper>
+        <SectionWrapper id="projetos" component={Projects} />
 
-        <SectionWrapper id="contato" className="pb-0">
-        <Contact />
-        </SectionWrapper>
+        <SectionWrapper id="contato" component={Contact} className="pb-0" />
       </div>
 
       {/* Footer sempre visível */}

--- a/components/section-wrapper.tsx
+++ b/components/section-wrapper.tsx
@@ -5,13 +5,14 @@ import { useEffect, useState, useRef } from "react"
 
 interface SectionWrapperProps {
   id: string
-  children: React.ReactNode
+  component: React.ComponentType
   className?: string
 }
 
-export function SectionWrapper({ id, children, className = "" }: SectionWrapperProps) {
+export function SectionWrapper({ id, component: Component, className = "" }: SectionWrapperProps) {
   const [isDissolving, setIsDissolving] = useState(false)
   const [isActive, setIsActive] = useState(id === "hero") // Hero ativo por padrão
+  const [hasBeenActive, setHasBeenActive] = useState(id === "hero")
   const sectionRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
@@ -22,6 +23,7 @@ export function SectionWrapper({ id, children, className = "" }: SectionWrapperP
         // Esta é a seção de destino - torna ativa e aplica efeito
         setIsActive(true)
         setIsDissolving(true)
+        setHasBeenActive(true)
 
         setTimeout(() => {
           setIsDissolving(false)
@@ -52,7 +54,7 @@ export function SectionWrapper({ id, children, className = "" }: SectionWrapperP
         transition-all duration-300 ease-out
       `}
     >
-      <div className="w-full">{children}</div>
+      <div className="w-full">{hasBeenActive ? <Component /> : null}</div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- load each content section only after it becomes active
- dynamically import non-critical sections to reduce initial payload

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_689b425680e883339a5196c1f037906f